### PR TITLE
Added bottomPanel to defaultFrontstage

### DIFF
--- a/common/changes/@bentley/itwin-viewer-react/modifyDefaultFrontstage_2020-09-28-18-25.json
+++ b/common/changes/@bentley/itwin-viewer-react/modifyDefaultFrontstage_2020-09-28-18-25.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "Added bottom panel to defaultFrontstage",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "22119573+nick4598@users.noreply.github.com"
+}

--- a/common/changes/@bentley/itwin-viewer-react/modifyDefaultFrontstage_2020-09-28-18-57.json
+++ b/common/changes/@bentley/itwin-viewer-react/modifyDefaultFrontstage_2020-09-28-18-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "Also added left panel to defaultFrontstage",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "22119573+nick4598@users.noreply.github.com"
+}

--- a/packages/modules/itwin-viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
+++ b/packages/modules/itwin-viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
@@ -2,6 +2,10 @@
  * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
  * See LICENSE.md in the project root for license terms and full copyright notice.
  *--------------------------------------------------------------------------------------------*/
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 import { Id64 } from "@bentley/bentleyjs-core";
 import { ViewState } from "@bentley/imodeljs-frontend";
@@ -191,6 +195,7 @@ export class DefaultFrontstage extends FrontstageProvider {
           />
         }
         rightPanel={<StagePanel allowedZones={[6, 9]} />}
+        bottomPanel={<StagePanel allowedZones={[7, 8, 9]} />}
       />
     );
   }

--- a/packages/modules/itwin-viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
+++ b/packages/modules/itwin-viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
@@ -1,11 +1,7 @@
 /*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
-/*---------------------------------------------------------------------------------------------
- * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
- * See LICENSE.md in the project root for license terms and full copyright notice.
- *--------------------------------------------------------------------------------------------*/
+* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+* See LICENSE.md in the project root for license terms and full copyright notice.
+*--------------------------------------------------------------------------------------------*/
 
 import { Id64 } from "@bentley/bentleyjs-core";
 import { ViewState } from "@bentley/imodeljs-frontend";

--- a/packages/modules/itwin-viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
+++ b/packages/modules/itwin-viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
@@ -192,6 +192,7 @@ export class DefaultFrontstage extends FrontstageProvider {
         }
         rightPanel={<StagePanel allowedZones={[6, 9]} />}
         bottomPanel={<StagePanel allowedZones={[7, 8, 9]} />}
+        leftPanel={<StagePanel allowedZones={[1, 4, 7]} />}
       />
     );
   }

--- a/packages/modules/itwin-viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
+++ b/packages/modules/itwin-viewer-react/src/components/app-ui/frontstages/DefaultFrontstage.tsx
@@ -1,7 +1,7 @@
 /*---------------------------------------------------------------------------------------------
-* Copyright (c) Bentley Systems, Incorporated. All rights reserved.
-* See LICENSE.md in the project root for license terms and full copyright notice.
-*--------------------------------------------------------------------------------------------*/
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *--------------------------------------------------------------------------------------------*/
 
 import { Id64 } from "@bentley/bentleyjs-core";
 import { ViewState } from "@bentley/imodeljs-frontend";


### PR DESCRIPTION
In order to add the modelAlignmentTable to the bottom of the frontstage a bottomPanel is necessary. This is because the UiItemsProvider only adds widgets to panels that exist in the frontstage. 
Without this bottomPanel, the modelAlignmentTable widget gets ignored.