### PR TITLE
Initialize FrameworkUiAdmin at startup.

### DIFF
--- a/common/changes/@bentley/itwin-viewer-react/initializeFrameworkUiAdmin_2020-11-11-19-52.json
+++ b/common/changes/@bentley/itwin-viewer-react/initializeFrameworkUiAdmin_2020-11-11-19-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "Initialize FrameworkUiAdmin at startup so popup like context menus, tool settings, cards, and toolbars can be shown and hidden via ImodelApp.uiAdmin calls.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/packages/modules/itwin-viewer-react/src/services/Initializer.ts
+++ b/packages/modules/itwin-viewer-react/src/services/Initializer.ts
@@ -16,6 +16,7 @@ import { UiCore } from "@bentley/ui-core";
 import {
   AppNotificationManager,
   FrameworkReducer,
+  FrameworkUiAdmin,
   StateManager,
   UiFramework,
 } from "@bentley/ui-framework";
@@ -140,6 +141,9 @@ class Initializer {
         // Use the AppNotificationManager subclass from ui-framework to get prompts and messages
         appOptions.notifications = new AppNotificationManager();
 
+        // Set FrameworkUiAdmin as default uiAdmin which is used to display context menus, (toolbars, card, tool setting) popups and dialogs.
+        appOptions.uiAdmin = new FrameworkUiAdmin();
+
         // Initialize state manager for extensions to have access to extending the redux store
         // This will setup a singleton store inside the StoreManager class.
         new StateManager({
@@ -201,6 +205,9 @@ class Initializer {
         await Presentation.initialize({
           activeLocale: IModelApp.i18n.languageList()[0],
         });
+
+        // allow uiAdmin to open key-in palette when Ctrl+F2 is pressed - good for manually loading extensions
+        IModelApp.uiAdmin.updateFeatureFlags({ allowKeyinPalette: true });
 
         AppUi.initialize();
 

--- a/packages/modules/itwin-viewer-react/src/tests/components/Viewer.test.tsx
+++ b/packages/modules/itwin-viewer-react/src/tests/components/Viewer.test.tsx
@@ -55,6 +55,9 @@ jest.mock("@bentley/imodeljs-frontend", () => {
         }),
         languageList: jest.fn().mockReturnValue(["en-US"]),
       },
+      uiAdmin: {
+        updateFeatureFlags: jest.fn(),
+      },
     },
     SnapMode: {},
     ActivityMessageDetails: jest.fn(),

--- a/packages/modules/itwin-viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
+++ b/packages/modules/itwin-viewer-react/src/tests/components/iModel/IModelLoader.test.tsx
@@ -34,6 +34,9 @@ jest.mock("@bentley/imodeljs-frontend", () => {
         languageList: jest.fn().mockReturnValue(["en-US"]),
         translate: jest.fn(),
       },
+      uiAdmin: {
+        updateFeatureFlags: jest.fn(),
+      },
     },
     SnapMode: {},
     ActivityMessageDetails: jest.fn(),

--- a/packages/modules/itwin-viewer-react/src/tests/services/ItwinViewer.test.ts
+++ b/packages/modules/itwin-viewer-react/src/tests/services/ItwinViewer.test.ts
@@ -55,6 +55,9 @@ jest.mock("@bentley/imodeljs-frontend", () => {
         }),
         languageList: jest.fn().mockReturnValue(["en-US"]),
       },
+      uiAdmin: {
+        updateFeatureFlags: jest.fn(),
+      },
     },
     SnapMode: {},
     ActivityMessageDetails: jest.fn(),


### PR DESCRIPTION
  Add following code to set FrameworkUiAdmin as default uiAdmin. This uiAdmin is used to display context menus, (toolbars, card, tool setting) popups and dialogs.
```ts
appOptions.uiAdmin = new FrameworkUiAdmin();
```
