### PR TITLE
Fix loader position and set viewer height to 100%

### DIFF
--- a/common/changes/@bentley/itwin-viewer-react/fix-loader-position_2021-02-05-19-05.json
+++ b/common/changes/@bentley/itwin-viewer-react/fix-loader-position_2021-02-05-19-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "Fix loading spinner position and change viewer height to 100%. REQUIRES CONTAINER ELEMENTS TO HAVE AN EXPLICIT HEIGHT",
+      "type": "major"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/packages/apps/viewer-sample-react/src/components/home/Home.module.scss
+++ b/packages/apps/viewer-sample-react/src/components/home/Home.module.scss
@@ -87,3 +87,7 @@
     }
   }
 }
+
+.home {
+  height: calc(100vh - 50px);
+}

--- a/packages/modules/itwin-viewer-react/src/components/iModel/IModelBusy.scss
+++ b/packages/modules/itwin-viewer-react/src/components/iModel/IModelBusy.scss
@@ -6,10 +6,6 @@
 
 .imodelbusy__centered {
   color: var(--buic-foreground-body-rgb, 000, 000, 000);
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
   text-align: center;
 
   .imodelbusy__loadingTitle {

--- a/packages/modules/itwin-viewer-react/src/components/iModel/IModelLoader.scss
+++ b/packages/modules/itwin-viewer-react/src/components/iModel/IModelLoader.scss
@@ -3,5 +3,12 @@
 * See LICENSE.md in the project root for license terms and full copyright notice.
 *--------------------------------------------------------------------------------------------*/
 .itwin-viewer-container {
-  height: 100vh;
+  height: 100%;
+}
+
+.itwin-viewer-loading-container {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/packages/modules/itwin-viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/itwin-viewer-react/src/components/iModel/IModelLoader.tsx
@@ -6,7 +6,6 @@
 import "@bentley/icons-generic-webfont/dist/bentley-icons-generic-webfont.css";
 import "./IModelLoader.scss";
 
-import { ClientRequestContext, Config } from "@bentley/bentleyjs-core";
 import {
   IModelApp,
   IModelConnection,
@@ -15,7 +14,6 @@ import {
   SnapshotConnection,
   ViewState,
 } from "@bentley/imodeljs-frontend";
-import { UrlDiscoveryClient } from "@bentley/itwin-client";
 import { useErrorManager } from "@bentley/itwin-error-handling-react";
 import {
   BackstageActionItem,
@@ -270,21 +268,25 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
     if (error) {
       throw error;
     } else {
-      return finalFrontstages &&
-        finalBackstageItems &&
-        connected &&
-        StateManager.store ? (
+      return (
         <div className="itwin-viewer-container">
-          <Provider store={StateManager.store}>
-            <IModelViewer
-              frontstages={finalFrontstages}
-              backstageItems={finalBackstageItems}
-              uiFrameworkVersion={uiFrameworkVersion}
-            />
-          </Provider>
+          {finalFrontstages &&
+          finalBackstageItems &&
+          connected &&
+          StateManager.store ? (
+            <Provider store={StateManager.store}>
+              <IModelViewer
+                frontstages={finalFrontstages}
+                backstageItems={finalBackstageItems}
+                uiFrameworkVersion={uiFrameworkVersion}
+              />
+            </Provider>
+          ) : (
+            <div className="itwin-viewer-loading-container">
+              <IModelBusy />
+            </div>
+          )}
         </div>
-      ) : (
-        <IModelBusy />
       );
     }
   }


### PR DESCRIPTION
This will be a breaking change and a new major version unfortunately. This will require an explicit height on parent elements of the Viewer. We no longer assume 100vh and will give consumers the flexibility to control the height of the Viewer control.

Will update styling in the CRA template once v6 is published

Closes #75 
