### PR TITLE
Fix issue causing footer separator to console warn and not render

### DIFF
--- a/common/changes/@bentley/itwin-viewer-react/fixFooterSeparator_2021-02-09-16-00.json
+++ b/common/changes/@bentley/itwin-viewer-react/fixFooterSeparator_2021-02-09-16-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "Update statusbar to pass ReactNode and not a function to return a ReactNode.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "65047615+bsteinbk@users.noreply.github.com"
+}

--- a/packages/modules/itwin-viewer-react/src/components/app-ui/statusbars/AppStatusBar.tsx
+++ b/packages/modules/itwin-viewer-react/src/components/app-ui/statusbars/AppStatusBar.tsx
@@ -44,8 +44,7 @@ export class AppStatusBarWidget extends StatusBarWidgetControl {
     this._footerModeOnlySeparator = (): React.ReactNode => {
       return (
         <FooterOnlyDisplay>
-          {" "}
-          <FooterSeparator />{" "}
+          <FooterSeparator />
         </FooterOnlyDisplay>
       );
     };
@@ -63,7 +62,7 @@ export class AppStatusBarWidget extends StatusBarWidgetControl {
         "PreToolAssistance",
         StatusBarSection.Left,
         15,
-        this._footerModeOnlySeparator
+        this._footerModeOnlySeparator()
       )
     );
     this._statusBarItems.push(
@@ -79,7 +78,7 @@ export class AppStatusBarWidget extends StatusBarWidgetControl {
         "PostToolAssistance",
         StatusBarSection.Left,
         25,
-        this._footerModeOnlySeparator
+        this._footerModeOnlySeparator()
       )
     );
 


### PR DESCRIPTION
StatusBarItemUtilities.createStatusBarItem requires a real ReactNode and not a function to create a ReactNode.