### PR TITLE
Add viewportOptions to dependency list

### DIFF
--- a/common/changes/@bentley/itwin-viewer-react/fix-vpOptions_2021-02-09-19-48.json
+++ b/common/changes/@bentley/itwin-viewer-react/fix-vpOptions_2021-02-09-19-48.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "add viewportOptions to dependency list",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/packages/modules/itwin-viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/itwin-viewer-react/src/components/iModel/IModelLoader.tsx
@@ -263,7 +263,7 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
       }
 
       setFinalFrontstages(allFrontstages);
-    }, [frontstages, viewState]);
+    }, [frontstages, viewportOptions, viewState]);
 
     if (error) {
       throw error;


### PR DESCRIPTION
Add viewportOptions to dependency list in IModelLoader which should fix the rendering issue seen by the dev ecosystem team.