### PR TITLE
remove DrawingViewDefinition from list of accepted classes

### DIFF
--- a/common/changes/@bentley/itwin-viewer-react/remove-drawing_2021-02-10-18-42.json
+++ b/common/changes/@bentley/itwin-viewer-react/remove-drawing_2021-02-10-18-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "Remove DrawingViewDefinition from list of accepted classes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "6283674+kckst8@users.noreply.github.com"
+}

--- a/packages/modules/itwin-viewer-react/src/services/iModel/IModelService.ts
+++ b/packages/modules/itwin-viewer-react/src/services/iModel/IModelService.ts
@@ -46,10 +46,9 @@ const getVersion = async (
 
 /** parse the comma-delimited config value that is a list of accepted schema:classnames or return a default */
 const getAcceptedViewClasses = (): string[] => {
-  // TODO configurable?
+  // TODO configurable? support for 2d (DrawingViewDefinition)?
   const acceptedClasses = [
     "BisCore:SpatialViewDefinition",
-    "BisCore:DrawingViewDefinition",
     "BisCore:OrthographicViewDefinition",
   ];
   return acceptedClasses;


### PR DESCRIPTION
At the moment this is a 3d viewer and does not properly support 2d, so including this class could potentially do more harm than good