### PR TITLE
remove unecessary deps

### DIFF
--- a/common/changes/@bentley/itwin-viewer-react/rm-deps_2021-03-08-16-52.json
+++ b/common/changes/@bentley/itwin-viewer-react/rm-deps_2021-03-08-16-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "remove unecessary deps",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/packages/modules/itwin-viewer-react/package.json
+++ b/packages/modules/itwin-viewer-react/package.json
@@ -52,9 +52,7 @@
     "oidc-client": "^1.10.1",
     "react-redux": "^7.2.0",
     "react-spring": "^8.0.27",
-    "redux": "^4.0.5",
-    "redux-devtools-extension": "^2.13.8",
-    "rewire": "^5.0.0"
+    "redux": "^4.0.5"
   },
   "devDependencies": {
     "@bentley/bentleyjs-core": "^2.6.4",


### PR DESCRIPTION
remove deps on rewire and redux-devtools-extension

rewire was being used earlier to generate the cdn variant, which we dont do here.
we dont create or manage our own redux store, core does that with the state manager which should already be using the redux-devtools-extension 