### PR TITLE
Fix blank viewer onImodelConnected not getting run

### DIFF
--- a/common/changes/@bentley/itwin-viewer-react/fix-BlankViewer-OnIModelConnected_2021-04-21-17-24.json
+++ b/common/changes/@bentley/itwin-viewer-react/fix-BlankViewer-OnIModelConnected_2021-04-21-17-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@bentley/itwin-viewer-react",
+      "comment": "run onIModelConnected callback when creating a BlankViewer",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@bentley/itwin-viewer-react",
+  "email": "aruniverse@users.noreply.github.com"
+}

--- a/packages/modules/itwin-viewer-react/src/components/iModel/IModelLoader.tsx
+++ b/packages/modules/itwin-viewer-react/src/components/iModel/IModelLoader.tsx
@@ -103,7 +103,8 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
      */
     const initBlankConnection = (
       blankConnection: BlankConnectionProps,
-      viewStateOptions?: BlankConnectionViewState
+      viewStateOptions?: BlankConnectionViewState,
+      onIModelConnected?: (iModel: IModelConnection) => void
     ) => {
       const imodelConnection = BlankConnection.create(blankConnection);
       const viewState = ViewCreator.createBlankViewState(
@@ -111,7 +112,13 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
         viewStateOptions
       );
       UiFramework.setIModelConnection(imodelConnection);
+
+      if (onIModelConnected) {
+        onIModelConnected(imodelConnection);
+      }
+
       UiFramework.setDefaultViewState(viewState);
+
       setViewState(viewState);
       setConnected(true);
     };
@@ -144,7 +151,11 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
         setConnected(false);
 
         if (blankConnection) {
-          return initBlankConnection(blankConnection, blankConnectionViewState);
+          return initBlankConnection(
+            blankConnection,
+            blankConnectionViewState,
+            onIModelConnected
+          );
         }
 
         if (!(contextId && iModelId) && !snapshotPath) {
@@ -218,7 +229,6 @@ const Loader: React.FC<ModelLoaderProps> = React.memo(
           }
 
           setViewState(savedViewState);
-
           setConnected(true);
         }
       };


### PR DESCRIPTION
Some UiProviders rely on the iModelConnection to register themselves (ie: reality-data)
BlankViewer accepted a prop for onIModelConnected callback, but was never run